### PR TITLE
build: Don't set ISPC target OS to the machine that currently runs the build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,34 +1,15 @@
 extern crate ispc_rt;
 
-#[cfg(feature = "ispc")]
 /*
 ISPC project file builds the kernels as such:
 <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ispc -O2 "%(Filename).ispc" -o "$(TargetDir)%(Filename).obj" -h "$(ProjectDir)%(Filename)_ispc.h" --target=sse2,sse4,avx,avx2 --opt=fast-math</Command>
 <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(TargetDir)%(Filename).obj;$(TargetDir)%(Filename)_sse2.obj;$(TargetDir)%(Filename)_sse4.obj;$(TargetDir)%(Filename)_avx.obj;$(TargetDir)%(Filename)_avx2.obj;</Outputs>
 */
-#[cfg(feature = "ispc")]
-use ispc_compile::{TargetISA, TargetOS};
-
-#[cfg(feature = "ispc")]
-#[cfg(target_os = "linux")]
-fn get_target_os() -> TargetOS {
-    TargetOS::Linux
-}
-
-#[cfg(feature = "ispc")]
-#[cfg(target_os = "windows")]
-fn get_target_os() -> TargetOS {
-    TargetOS::Windows
-}
-
-#[cfg(feature = "ispc")]
-#[cfg(target_os = "macos")]
-fn get_target_os() -> TargetOS {
-    TargetOS::Macos
-}
 
 #[cfg(feature = "ispc")]
 fn compile_kernel() {
+    use ispc_compile::TargetISA;
+
     ispc_compile::Config::new()
         .file("vendor/ispc_texcomp/kernel.ispc")
         .opt_level(2)
@@ -41,7 +22,6 @@ fn compile_kernel() {
             TargetISA::AVX512KNLi32x16,
             TargetISA::AVX512SKXi32x16,
         ])
-        .target_os(get_target_os())
         .out_dir("src/ispc")
         .compile("kernel");
 
@@ -57,7 +37,6 @@ fn compile_kernel() {
             TargetISA::AVX512KNLi32x16,
             TargetISA::AVX512SKXi32x16,
         ])
-        .target_os(get_target_os())
         .out_dir("src/ispc")
         .compile("kernel_astc");
 


### PR DESCRIPTION
Patch from https://github.com/Traverse-Research/ispc-downsampler/pull/4 reapplied here

The `CARGO_CFG_TARGET_OS` environment variable should be used for this, as `cfg!()` represents the target the `build.rs` script was compiled for and will contain the wrong value when cross-compiling for a different target.

Empirical evidence suggests that it's not necessary to explicitly set `target_os` anyway since it is already conveyed in the `TARGET` triple environment variable.  It's not passed directly to ispc but at least `ispc-rs` uses it to identify the architecture, and it should should be irrelevant when not linking against external libraries.
