### PR TITLE
Automatically fix new clippy lints since Rust 1.67.1

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use ddsfile::{AlphaMode, Caps2, D3D10ResourceDimension, Dds, DxgiFormat, NewDxgiParams};
 
 fn main() {
-    let rgb_img = image::open(&Path::new("examples/lambertian.jpg")).unwrap();
+    let rgb_img = image::open(Path::new("examples/lambertian.jpg")).unwrap();
 
     let (width, height) = rgb_img.dimensions();
     println!("Width is {}", width);

--- a/src/astc.rs
+++ b/src/astc.rs
@@ -156,7 +156,7 @@ pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, bl
     let mode_list_size = 3334usize;
     let list_size = program_count as usize;
 
-    let mut mode_lists: Vec<u64> = vec![0; (list_size * mode_list_size) as usize];
+    let mut mode_lists: Vec<u64> = vec![0; list_size * mode_list_size];
     let mut mode_buffer: Vec<u32> =
         vec![0; (program_count * settings.fast_skip_threshold) as usize];
 
@@ -176,7 +176,7 @@ pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, bl
     };
 
     for yy in 0..(surface.height / settings.block_height) as u32 {
-        for xx in 0..((tex_width + program_count - 1) / program_count) as u32 {
+        for xx in 0..((tex_width + program_count - 1) / program_count) {
             let xx = xx * program_count;
             astc_rank(&mut settings, &mut surface, xx, yy, &mut mode_buffer);
             for i in 0..settings.fastSkipTreshold as u32 {

--- a/src/bc4.rs
+++ b/src/bc4.rs
@@ -37,7 +37,7 @@ pub fn compress_blocks_into(surface: &RgbaSurface, blocks: &mut [u8]) {
         width: surface.width as i32,
         height: surface.height as i32,
         stride: (surface.stride / 4) as i32,
-        ptr: (&r_data).as_ptr() as *mut u8,
+        ptr: r_data.as_ptr() as *mut u8,
     };
 
     unsafe {

--- a/src/bc5.rs
+++ b/src/bc5.rs
@@ -38,7 +38,7 @@ pub fn compress_blocks_into(surface: &RgbaSurface, blocks: &mut [u8]) {
         width: surface.width as i32,
         height: surface.height as i32,
         stride: (surface.stride / 2) as i32,
-        ptr: (&rg_data).as_ptr() as *mut u8,
+        ptr: rg_data.as_ptr() as *mut u8,
     };
 
     unsafe {

--- a/src/bc7.rs
+++ b/src/bc7.rs
@@ -57,7 +57,7 @@ pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, bl
         fastSkipTreshold_mode7: settings.fast_skip_threshold_mode7 as i32,
         mode45_channel0: settings.mode45_channel0 as i32,
         refineIterations_channel: settings.refine_iterations_channel as i32,
-        channels: settings.channels as i32,
+        channels: settings.channels,
     };
 
     unsafe {


### PR DESCRIPTION
All lints are automatically fixed with `--fix`; `uninlined_format_args`
was demoted to `pedantic` and is not changed as part of this PR.
