### PR TITLE
build: Fix C++ library filename in `cargo:rerun-if-changed` on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -84,7 +84,7 @@ fn compile_kernel() {
     let libpath = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/ispc");
     let libfile = match std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap().as_str() {
         "unix" => format!("lib{}.a", libname),
-        "windows" => format!("lib{}.a", libname),
+        "windows" => format!("{}.lib", libname),
         x => panic!("Unknown target family {}", x),
     };
 


### PR DESCRIPTION
Commit 7b29fe4 ("build: Manually link `ispc_texcomp_astc` to prevent bogus `cargo:rerun-if-changed` lines causing full recompilation") removed a bogus `cargo:rerun-if-changed` for an inexistent `.rs` file.  The fix however now emits a similar broken `cargo:rerun-if-changed` with a Linux `lib{}.a` file rather than the Windows `{}.lib` format on Windows platforms - seemingly a copy-paste bug.  This turned out not to be too harmful as that file was present in the repo at some point, but got removed in b23be6a ("Upgrade `ispc-rs` to `2.0.0` (#11)") as we do not support Linux static `lib{}.a` files for the MSVC target.  And as known from the first commit, missing files always cause `cargo` to consider the crate as dirty and will always recompile it (and any other transitive dependencies depending on it):

       Dirty intel_tex_2 v0.2.1: the file `.cargo\registry\src\index.crates.io-6f17d22bba15001f\intel_tex_2-0.2.1\src/ispc\libispc_texcomp_astcx86_64-pc-windows-msvc.a` is missing
   Compiling intel_tex_2 v0.2.1

Simply substitute for the appropriate `{}.lib` format on Windows to solve this indefinite recompilation issue, and make the rerun actually rerun on changes.

The second commit where this library was removed is only part of our 0.2.1 release: the 0.2.0 was unaffected.
