### PR TITLE
Require and use stable `ispc_compile 2.0.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ maintenance = { status = "actively-developed" }
 ispc_rt = "2"
 
 [build-dependencies]
-ispc_compile = { version = "2", optional = true }
+ispc_compile = { version = "2.0.1", optional = true }
 cc = { version = "1", optional = true }
 ispc_rt = "2"
 
@@ -40,7 +40,3 @@ image = "0.24.1"
 lto = true
 opt-level = 3
 codegen-units = 1
-
-[patch.crates-io]
-# Includes https://github.com/Twinklebear/ispc-rs/commit/4e33959af030f59b2ab6696095a021ad919005dc
-ispc_compile = { git = "https://github.com/Twinklebear/ispc-rs", rev = "3b5c0b4" }


### PR DESCRIPTION
This release has fixed support for cross-compiling to `aarch64-pc-windows-msvc` 🎉
