### PR TITLE
add example for compressing bc6h

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ ispc = ["ispc_compile", "cc"]
 [dev-dependencies]
 ddsfile = "0.5.0"
 image = "0.25.1"
+half = "2.4.1"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
This behavior makes sense but isn't very obvious. Hopefully this saves someone the pain I endured a while ago figuring out why bc6h encoding crashed or didn't work as expected. It might be a good idea to add asserts for the surface data length in the future. Messing up the stride or data length will likely result in segfaults.