### PR TITLE
🎍 Consistent encode settings referencing

### DIFF
--- a/src/astc.rs
+++ b/src/astc.rs
@@ -151,7 +151,7 @@ pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, bl
     let program_count = unsafe { kernel_astc::get_programCount() as u32 };
 
     let mut block_scores =
-        vec![std::f32::INFINITY; (tex_width * surface.height / settings.block_height) as usize];
+        vec![f32::INFINITY; (tex_width * surface.height / settings.block_height) as usize];
 
     let mode_list_size = 3334usize;
     let list_size = program_count as usize;

--- a/src/etc1.rs
+++ b/src/etc1.rs
@@ -13,14 +13,14 @@ pub fn calc_output_size(width: u32, height: u32) -> usize {
     block_count as usize * 8
 }
 
-pub fn compress_blocks(settings: EncodeSettings, surface: &RgbaSurface) -> Vec<u8> {
+pub fn compress_blocks(settings: &EncodeSettings, surface: &RgbaSurface) -> Vec<u8> {
     let output_size = calc_output_size(surface.width, surface.height);
     let mut output = vec![0u8; output_size];
     compress_blocks_into(settings, surface, &mut output);
     output
 }
 
-pub fn compress_blocks_into(settings: EncodeSettings, surface: &RgbaSurface, blocks: &mut [u8]) {
+pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, blocks: &mut [u8]) {
     assert_eq!(
         blocks.len(),
         calc_output_size(surface.width, surface.height)


### PR DESCRIPTION
We always take a reference to EncodeSettings except for when we use etc1. This PR fixes that.