### PR TITLE
Assert when input data is too small for `RgbaSurface`

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -36,7 +36,7 @@ fn main() {
         }
     }
 
-    let block_count = intel_tex_2::divide_up_by_multiple(width * height, 16);
+    let block_count = (width as usize * height as usize).div_ceil(16);
     println!("Block count: {}", block_count);
     let dds_defaults = NewDxgiParams {
         height,

--- a/src/astc.rs
+++ b/src/astc.rs
@@ -126,8 +126,8 @@ fn astc_rank(
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // ASTC uses a fixed block size of 16 bytes (128 bits).
-    let block_count = crate::divide_up_by_multiple(width * height, 16);
-    block_count as usize * 16
+    let block_count = (width as usize * height as usize).div_ceil(16);
+    block_count * 16
 }
 
 pub fn compress_blocks(settings: &EncodeSettings, surface: &RgbaSurface) -> Vec<u8> {
@@ -177,7 +177,7 @@ pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, bl
     };
 
     for yy in 0..(surface.height / settings.block_height) as u32 {
-        for xx in 0..((tex_width + program_count - 1) / program_count) {
+        for xx in 0..tex_width.div_ceil(program_count) {
             let xx = xx * program_count;
             astc_rank(&mut settings, &mut surface, xx, yy, &mut mode_buffer);
             for i in 0..settings.fastSkipTreshold as u32 {

--- a/src/astc.rs
+++ b/src/astc.rs
@@ -146,6 +146,7 @@ pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, bl
         blocks.len(),
         calc_output_size(surface.width, surface.height)
     );
+    assert!(surface.data.len() >= surface.height as usize * surface.stride as usize);
 
     let tex_width = surface.width / settings.block_width;
     let program_count = unsafe { kernel_astc::get_programCount() as u32 };

--- a/src/bc1.rs
+++ b/src/bc1.rs
@@ -20,6 +20,8 @@ pub fn compress_blocks_into(surface: &RgbaSurface, blocks: &mut [u8]) {
         blocks.len(),
         calc_output_size(surface.width, surface.height)
     );
+    assert!(surface.data.len() >= surface.height as usize * surface.stride as usize);
+
     let mut surface = kernel::rgba_surface {
         width: surface.width as i32,
         height: surface.height as i32,

--- a/src/bc1.rs
+++ b/src/bc1.rs
@@ -4,7 +4,7 @@ use crate::RgbaSurface;
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC1 uses 8 bytes to store each 4×4 block, giving it an average data rate of 0.5 bytes per pixel.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = (width as usize * height as usize).div_ceil(16);
     block_count * 8
 }
 

--- a/src/bc3.rs
+++ b/src/bc3.rs
@@ -20,6 +20,8 @@ pub fn compress_blocks_into(surface: &RgbaSurface, blocks: &mut [u8]) {
         blocks.len(),
         calc_output_size(surface.width, surface.height)
     );
+    assert!(surface.data.len() >= surface.height as usize * surface.stride as usize);
+
     let mut surface = kernel::rgba_surface {
         width: surface.width as i32,
         height: surface.height as i32,

--- a/src/bc3.rs
+++ b/src/bc3.rs
@@ -4,7 +4,7 @@ use crate::RgbaSurface;
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC3 uses 16 bytes to store each 4×4 block, giving it an average data rate of 1 byte per pixel.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = (width as usize * height as usize).div_ceil(16);
     block_count * 16
 }
 

--- a/src/bc4.rs
+++ b/src/bc4.rs
@@ -20,6 +20,7 @@ pub fn compress_blocks_into(surface: &RSurface, blocks: &mut [u8]) {
         blocks.len(),
         calc_output_size(surface.width, surface.height)
     );
+    assert!(surface.data.len() >= surface.height as usize * surface.stride as usize);
 
     let mut surface = kernel::rgba_surface {
         width: surface.width as i32,

--- a/src/bc4.rs
+++ b/src/bc4.rs
@@ -4,7 +4,7 @@ use crate::RSurface;
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC4 uses 8 bytes to store each 4×4 block, giving it an average data rate of 0.5 bytes per pixel.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = (width as usize * height as usize).div_ceil(16);
     block_count * 8
 }
 

--- a/src/bc5.rs
+++ b/src/bc5.rs
@@ -4,7 +4,7 @@ use crate::RgSurface;
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC5 uses 16 bytes to store each 4×4 block, giving it an average data rate of 1 byte per pixel.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = (width as usize * height as usize).div_ceil(16);
     block_count * 16
 }
 

--- a/src/bc5.rs
+++ b/src/bc5.rs
@@ -20,6 +20,7 @@ pub fn compress_blocks_into(surface: &RgSurface, blocks: &mut [u8]) {
         blocks.len(),
         calc_output_size(surface.width, surface.height)
     );
+    assert!(surface.data.len() >= surface.height as usize * surface.stride as usize);
 
     let mut surface = kernel::rgba_surface {
         width: surface.width as i32,

--- a/src/bc6h.rs
+++ b/src/bc6h.rs
@@ -13,7 +13,7 @@ pub struct EncodeSettings {
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC6H uses a fixed block size of 16 bytes (128 bits) and a fixed tile size of 4x4 texels.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = (width as usize * height as usize).div_ceil(16);
     block_count * 16
 }
 

--- a/src/bc6h.rs
+++ b/src/bc6h.rs
@@ -29,6 +29,8 @@ pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, bl
         blocks.len(),
         calc_output_size(surface.width, surface.height)
     );
+    assert!(surface.data.len() >= surface.height as usize * surface.stride as usize);
+
     let mut surface = kernel::rgba_surface {
         width: surface.width as i32,
         height: surface.height as i32,

--- a/src/bc7.rs
+++ b/src/bc7.rs
@@ -33,6 +33,8 @@ pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, bl
         blocks.len(),
         calc_output_size(surface.width, surface.height)
     );
+    assert!(surface.data.len() >= surface.height as usize * surface.stride as usize);
+
     let mut surface = kernel::rgba_surface {
         width: surface.width as i32,
         height: surface.height as i32,

--- a/src/bc7.rs
+++ b/src/bc7.rs
@@ -17,7 +17,7 @@ pub struct EncodeSettings {
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC7 uses a fixed block size of 16 bytes (128 bits) and a fixed tile size of 4x4 texels.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = (width as usize * height as usize).div_ceil(16);
     block_count * 16
 }
 

--- a/src/etc1.rs
+++ b/src/etc1.rs
@@ -25,6 +25,8 @@ pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, bl
         blocks.len(),
         calc_output_size(surface.width, surface.height)
     );
+    assert!(surface.data.len() >= surface.height as usize * surface.stride as usize);
+
     let mut surface = kernel::rgba_surface {
         width: surface.width as i32,
         height: surface.height as i32,

--- a/src/etc1.rs
+++ b/src/etc1.rs
@@ -9,8 +9,8 @@ pub struct EncodeSettings {
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // ETC1 uses a fixed block size of 8 bytes (64 bits) and a fixed tile size of 4x4 texels.
-    let block_count = crate::divide_up_by_multiple(width * height, 16);
-    block_count as usize * 8
+    let block_count = (width as usize * height as usize).div_ceil(16);
+    block_count * 8
 }
 
 pub fn compress_blocks(settings: &EncodeSettings, surface: &RgbaSurface) -> Vec<u8> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,3 @@ pub struct Surface<'a, const COMPONENTS: usize> {
 pub type RgbaSurface<'a> = Surface<'a, 4>;
 pub type RgSurface<'a> = Surface<'a, 2>;
 pub type RSurface<'a> = Surface<'a, 1>;
-
-#[inline(always)]
-pub fn divide_up_by_multiple(val: u32, align: u32) -> u32 {
-    let mask: u32 = align - 1;
-    (val + mask) / align
-}


### PR DESCRIPTION
It is currently possible to trigger UB by reading uninitialized memory using the API, which result for example under Windows in a `STATUS_ACCESS_VIOLATION`:

```rust
use intel_tex_2::RgbaSurface;

fn main() {
    let pixel_size = size_of::<u32>() as u32;
    let width = 64;
    let height = 64;

    let input = vec![0xA1; (width * height * pixel_size) as usize];

    let output_size = intel_tex_2::bc3::calc_output_size(width, height);
    let mut output = vec![0x0; output_size];

    intel_tex_2::bc3::compress_blocks_into(
        &RgbaSurface {
            data: &input,
            width,
            height,
            stride: width * (pixel_size + 2),
        },
        &mut output,
    );
}
```

This PR makes sure that the data of the surface given actually is big enough for its height and stride.