### PR TITLE
CI: Sync up `generate-binaries` with `ispc-downsampler` slightly to include `aarch64-apple-ios`

### DIFF
--- a/.github/workflows/generate-binaries.yaml
+++ b/.github/workflows/generate-binaries.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ISPC kernels
+          name: ISPC kernels Linux
           path: |
             src/ispc/kernel.rs
             src/ispc/kernel_astc.rs
@@ -80,16 +80,17 @@ jobs:
           echo "$PWD" >> $GITHUB_PATH
 
       - name: Install additional targets
-        run: rustup target add aarch64-apple-darwin
+        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin aarch64-apple-ios
 
       - name: Build binaries
         run: |
           cargo build --features=ispc --target=x86_64-apple-darwin
           cargo build --features=ispc --target=aarch64-apple-darwin
+          cargo build --features=ispc --target=aarch64-apple-ios
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ISPC kernels
+          name: ISPC kernels Apple
           path: |
             src/ispc/lib*.a
 
@@ -122,6 +123,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ISPC kernels
+          name: ISPC kernels Windows
           path: |
             src/ispc/*.lib

--- a/src/astc.rs
+++ b/src/astc.rs
@@ -176,7 +176,7 @@ pub fn compress_blocks_into(settings: &EncodeSettings, surface: &RgbaSurface, bl
     };
 
     for yy in 0..(surface.height / settings.block_height) as u32 {
-        for xx in 0..((tex_width + program_count - 1) / program_count) {
+        for xx in 0..tex_width.div_ceil(program_count) {
             let xx = xx * program_count;
             astc_rank(&mut settings, &mut surface, xx, yy, &mut mode_buffer);
             for i in 0..settings.fastSkipTreshold as u32 {


### PR DESCRIPTION
And also make sure `x86_64-apple-darwin` is installed, since the `macos-latest` hosts are now `aarch64-apple-darwin` and this can no longer be assumed to be the default installed target.  And deduplicate the `upload-artifact` target names since independent steps are no longer allowed to upload "into the same ZIP" since updating to `v4` in #24.
