### PR TITLE
Block count calc fix

### DIFF
--- a/src/bc1.rs
+++ b/src/bc1.rs
@@ -4,7 +4,7 @@ use crate::RgbaSurface;
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC1 uses 8 bytes to store each 4×4 block, giving it an average data rate of 0.5 bytes per pixel.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = crate::divide_up_by_multiple(width, 4) * crate::divide_up_by_multiple(height, 4) as usize;
     block_count * 8
 }
 

--- a/src/bc3.rs
+++ b/src/bc3.rs
@@ -4,7 +4,7 @@ use crate::RgbaSurface;
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC3 uses 16 bytes to store each 4×4 block, giving it an average data rate of 1 byte per pixel.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = crate::divide_up_by_multiple(width, 4) * crate::divide_up_by_multiple(height, 4) as usize;
     block_count * 16
 }
 

--- a/src/bc4.rs
+++ b/src/bc4.rs
@@ -4,7 +4,7 @@ use crate::RSurface;
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC4 uses 8 bytes to store each 4×4 block, giving it an average data rate of 0.5 bytes per pixel.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = crate::divide_up_by_multiple(width, 4) * crate::divide_up_by_multiple(height, 4) as usize;
     block_count * 8
 }
 

--- a/src/bc5.rs
+++ b/src/bc5.rs
@@ -4,7 +4,7 @@ use crate::RgSurface;
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC5 uses 16 bytes to store each 4×4 block, giving it an average data rate of 1 byte per pixel.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = crate::divide_up_by_multiple(width, 4) * crate::divide_up_by_multiple(height, 4) as usize;
     block_count * 16
 }
 

--- a/src/bc6h.rs
+++ b/src/bc6h.rs
@@ -13,7 +13,7 @@ pub struct EncodeSettings {
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC6H uses a fixed block size of 16 bytes (128 bits) and a fixed tile size of 4x4 texels.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = crate::divide_up_by_multiple(width, 4) * crate::divide_up_by_multiple(height, 4) as usize;
     block_count * 16
 }
 

--- a/src/bc7.rs
+++ b/src/bc7.rs
@@ -17,7 +17,7 @@ pub struct EncodeSettings {
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // BC7 uses a fixed block size of 16 bytes (128 bits) and a fixed tile size of 4x4 texels.
-    let block_count = crate::divide_up_by_multiple(width * height, 16) as usize;
+    let block_count = crate::divide_up_by_multiple(width, 4) * crate::divide_up_by_multiple(height, 4) as usize;
     block_count * 16
 }
 

--- a/src/etc1.rs
+++ b/src/etc1.rs
@@ -9,7 +9,7 @@ pub struct EncodeSettings {
 #[inline(always)]
 pub fn calc_output_size(width: u32, height: u32) -> usize {
     // ETC1 uses a fixed block size of 8 bytes (64 bits) and a fixed tile size of 4x4 texels.
-    let block_count = crate::divide_up_by_multiple(width * height, 16);
+    let block_count = crate::divide_up_by_multiple(width, 4) * crate::divide_up_by_multiple(height, 4) as usize;
     block_count as usize * 8
 }
 


### PR DESCRIPTION
The previous block count calculation worked for most resolutions.  However, some degenerate resolutions received the wrong block counts.

Take a 2x7 image for example.  The previous calculation would give it a block count of 1, since 2*7=14, and 14/16 rounded up was 1.

However, this image should have 2 blocks.  A 2x4 block, and a 2x3 block.